### PR TITLE
Handle error thrown by socket.addMembership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### :syringe: Fixed
+
+- Add membership to port 1900 might throw error if already in use by another process
+
 ## [5.0.5] - 2019-12-27
 
 ### :policeman: Security

--- a/src/sockets/MSearch.ts
+++ b/src/sockets/MSearch.ts
@@ -19,6 +19,6 @@ export class MSearch {
      * Converts the M-SEARCH request into a buffer.
      */
     public toBuffer(): Buffer {
-        return new Buffer(MSearch.Payload);
+        return Buffer.from(MSearch.Payload);
     }
 }

--- a/src/sockets/NotifySocket.ts
+++ b/src/sockets/NotifySocket.ts
@@ -24,7 +24,11 @@ export class NotifySocket extends SocketBase {
 
         for (const address of this.addresses) {
             log('NotifySocket#onListening - add membership to %s', address);
-            this.socket.addMembership(SSDP_MULTICAST_ADDRESS, address);
+            try {
+                this.socket.addMembership(SSDP_MULTICAST_ADDRESS, address);
+            } catch (error) {
+                log('NotifySocket#onListening - %o', error);
+            }
         }
     }
 

--- a/test/sockets/Mappings.spec.ts
+++ b/test/sockets/Mappings.spec.ts
@@ -24,7 +24,7 @@ describe('Mappings', function () {
             // Arrange
             const message = new Message(
                 '192.168.1.102',
-                new Buffer(NOTIFY_MESSAGE));
+                Buffer.from(NOTIFY_MESSAGE));
 
             // Act
             const actual = mapFromMessage(message);
@@ -43,7 +43,7 @@ describe('Mappings', function () {
             // Arrange
             const message = new Message(
                 '192.168.1.102',
-                new Buffer(NOTIFY_MESSAGE_WITH_LOWERCASE_MACADDRESS));
+                Buffer.from(NOTIFY_MESSAGE_WITH_LOWERCASE_MACADDRESS));
 
             // Act
             const actual = mapFromMessage(message);
@@ -56,7 +56,7 @@ describe('Mappings', function () {
             // Arrange
             const message = new Message(
                 '192.168.1.102',
-                new Buffer(NOTIFY_MESSAGE_WITHOUT_MAC_IN_USN));
+                Buffer.from(NOTIFY_MESSAGE_WITHOUT_MAC_IN_USN));
 
             // Act
             const actual = mapFromMessage(message);
@@ -69,7 +69,7 @@ describe('Mappings', function () {
             // Arrange
             const message = new Message(
                 '192.168.1.102',
-                new Buffer(MSEARCH_MESSAGE));
+                Buffer.from(MSEARCH_MESSAGE));
 
             // Act
             const actual = mapFromMessage(message);
@@ -88,7 +88,7 @@ describe('Mappings', function () {
             // Arrange
             const message = new Message(
                 '192.168.1.102',
-                new Buffer(MSEARCH_MESSAGE_WITH_LOWERCASE_MACADDRESS));
+                Buffer.from(MSEARCH_MESSAGE_WITH_LOWERCASE_MACADDRESS));
 
             // Act
             const actual = mapFromMessage(message);
@@ -101,7 +101,7 @@ describe('Mappings', function () {
             // Arrange
             const message = new Message(
                 '192.168.1.102',
-                new Buffer(MSEARCH_MESSAGE_WITHOUT_MAC_IN_USN));
+                Buffer.from(MSEARCH_MESSAGE_WITHOUT_MAC_IN_USN));
 
             // Act
             const actual = mapFromMessage(message);

--- a/test/sockets/Message.spec.ts
+++ b/test/sockets/Message.spec.ts
@@ -12,7 +12,7 @@ describe('Message', function () {
 
     it('#remoteAddress', function () {
         // Arrange
-        const subject = new Message('192.168.1.100', new Buffer('HTTP/1.1 200 OK'));
+        const subject = new Message('192.168.1.100', Buffer.from('HTTP/1.1 200 OK'));
 
         // Assert
         subject.remoteAddress.should.equal('192.168.1.100');
@@ -22,7 +22,7 @@ describe('Message', function () {
         // Arrange
         const subject = new Message(
             '192.168.1.100',
-            new Buffer(
+            Buffer.from(
                 'HTTP/1.1 200 OK\r\n' +
                 ' USN: uuid:Upnp-BasicDevice-1_0-ACCC8E270AD8::urn:axis-com:service:BasicService:1 \r\n'));
 
@@ -33,7 +33,7 @@ describe('Message', function () {
     describe('M-SEARCH response', () => {
         it('#method', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(MSEARCH_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(MSEARCH_MESSAGE));
 
             // Assert
             subject.method.should.equal('HTTP/1.1 200 OK');
@@ -41,7 +41,7 @@ describe('Message', function () {
 
         it('#location', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(MSEARCH_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(MSEARCH_MESSAGE));
 
             // Assert
             subject.location.should.equal('http://192.168.1.102:45895/rootdesc1.xml');
@@ -49,7 +49,7 @@ describe('Message', function () {
 
         it('#usn', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(MSEARCH_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(MSEARCH_MESSAGE));
 
             // Assert
             subject.usn.should.equal('uuid:Upnp-BasicDevice-1_0-ACCC8E270AD8::urn:axis-com:service:BasicService:1');
@@ -57,7 +57,7 @@ describe('Message', function () {
 
         it('#location should fail if missing', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer('HTTP/1.1 200 OK\r\n'));
+            const subject = new Message('192.168.1.100', Buffer.from('HTTP/1.1 200 OK\r\n'));
 
             // Assert
             (() => subject.location).should.throw();
@@ -65,7 +65,7 @@ describe('Message', function () {
 
         it('#usn should fail if missing', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer('HTTP/1.1 200 OK\r\n'));
+            const subject = new Message('192.168.1.100', Buffer.from('HTTP/1.1 200 OK\r\n'));
 
             // Assert
             (() => subject.usn).should.throw();
@@ -75,7 +75,7 @@ describe('Message', function () {
     describe('NOTIFY', () => {
         it('#method', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(NOTIFY_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(NOTIFY_MESSAGE));
 
             // Assert
             subject.method.should.equal('NOTIFY * HTTP/1.1');
@@ -83,7 +83,7 @@ describe('Message', function () {
 
         it('#location', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(NOTIFY_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(NOTIFY_MESSAGE));
 
             // Assert
             subject.location.should.equal('http://192.168.1.102:45895/rootdesc1.xml');
@@ -91,7 +91,7 @@ describe('Message', function () {
 
         it('#location should fail if missing', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer('HTTP/1.1 200 OK\r\n'));
+            const subject = new Message('192.168.1.100', Buffer.from('HTTP/1.1 200 OK\r\n'));
 
             // Assert
             (() => subject.location).should.throw();
@@ -99,7 +99,7 @@ describe('Message', function () {
 
         it('#usn', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(NOTIFY_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(NOTIFY_MESSAGE));
 
             // Assert
             subject.usn.should.equal('uuid:Upnp-BasicDevice-1_0-ACCC8E270AD8::urn:axis-com:service:BasicService:1');
@@ -107,7 +107,7 @@ describe('Message', function () {
 
         it('#usn should fail if missing', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer('HTTP/1.1 200 OK\r\n'));
+            const subject = new Message('192.168.1.100', Buffer.from('HTTP/1.1 200 OK\r\n'));
 
             // Assert
             (() => subject.usn).should.throw();
@@ -115,7 +115,7 @@ describe('Message', function () {
 
         it('#nt', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(NOTIFY_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(NOTIFY_MESSAGE));
 
             // Assert
             subject.nt.should.equal('urn:axis-com:service:BasicService:1');
@@ -123,7 +123,7 @@ describe('Message', function () {
 
         it('#nt should fail if missing', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer('HTTP/1.1 200 OK\r\n'));
+            const subject = new Message('192.168.1.100', Buffer.from('HTTP/1.1 200 OK\r\n'));
 
             // Assert
             (() => subject.nt).should.throw();
@@ -131,7 +131,7 @@ describe('Message', function () {
 
         it('#nts', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer(NOTIFY_MESSAGE));
+            const subject = new Message('192.168.1.100', Buffer.from(NOTIFY_MESSAGE));
 
             // Assert
             subject.nts.should.equal('ssdp:byebye');
@@ -139,7 +139,7 @@ describe('Message', function () {
 
         it('#nts should fail if missing', function () {
             // Arrange
-            const subject = new Message('192.168.1.100', new Buffer('HTTP/1.1 200 OK\r\n'));
+            const subject = new Message('192.168.1.100', Buffer.from('HTTP/1.1 200 OK\r\n'));
 
             // Assert
             (() => subject.nts).should.throw();


### PR DESCRIPTION
We passively listen for SSDP announcements on port 1900. This port is already in use on some computers. We have to handle that, we currently don't.